### PR TITLE
BUG: docker compose prod tag indented wrongly

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -4,29 +4,29 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: prod
+      tags:
+        - "10.50.0.7:5001/csam_ai_training/app:latest"
+        - "10.50.0.7:5001/csam_ai_training/app:1.0.0"
     volumes:
       - ./backend/data:/api/data
       - ./backend/conf:/api/conf
-    tags:
-      - "10.50.0.7:5001/csam_ai_training/app:latest"
-      - "10.50.0.7:5001/csam_ai_training/app:1.0.0"
   app:
     build:
       context: ./frontend
       dockerfile: Dockerfile
       target: prod
+      tags:
+        - "10.50.0.7:5001/csam_ai_training/app:latest"
+        - "10.50.0.7:5001/csam_ai_training/app:1.0.0"
       args:
         - APP_PORT=${APP_PORT}
         - NGINX_PORT=${NGINX_PORT}
         - FASTAPI_ROOT=${FASTAPI_ROOT}
         - PC_NAME=${PC_NAME}
-    tags:
-      - "10.50.0.7:5001/csam_ai_training/app:latest"
-      - "10.50.0.7:5001/csam_ai_training/app:1.0.0"
   nginx:
     build:
       context: ./nginx
       dockerfile: Dockerfile
-    tags:
-      - "10.50.0.7:5001/csam_ai_training/nginx:latest"
-      - "10.50.0.7:5001/csam_ai_training/nginx:1.0.0"
+      tags:
+        - "10.50.0.7:5001/csam_ai_training/nginx:latest"
+        - "10.50.0.7:5001/csam_ai_training/nginx:1.0.0"


### PR DESCRIPTION
Production tag creation under build in the docker compose yml file is wrongly indented.

Fix by indenting them correctly.